### PR TITLE
Adapter settings entities custom button

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ Thumbs.db
 admin/i18n/flat.txt
 admin/i18n/*/flat.txt
 /package-lock.json
+*.code-workspace

--- a/admin/index_m.html
+++ b/admin/index_m.html
@@ -100,7 +100,14 @@
                 });
                 var click2copy = _('Click to copy');
                 for (var i = 0; i < list.length; i++) {
-                    text += '<tr><td class="entity-id" title="' + click2copy + '">' + list[i].entity_id + '</td>';
+                    text += '<tr>';
+
+                    if (list[i].isManual) {
+                        text += '<td><a class="btn-floating btn-small waves-effect waves-light open-custom" data-name="' + list[i].context.id + '"><i class="material-icons">build</i></a></td>';
+                    } else {
+                        text += '<td><a class="btn-floating btn-small waves-effect waves-light open-custom" data-name="' + list[i].context.id + '" disabled="true"><i class="material-icons">build</i></a></td>';
+                    }
+                    text += '<td class="entity-id" title="' + click2copy + '">' + list[i].entity_id + '</td>';
                     text += '<td>' + formatIds(list[i].context.STATE) + '</td><td class="attributes">';
 
                     if (list[i].context.ATTRIBUTES) {
@@ -125,6 +132,11 @@
                 }
 
                 $entities.find('.entity-id').on('click', clippyCopy);
+
+                $entities.find('.open-custom').off('click').on('click', function () {
+                    let url = `${window.location.origin}/#tab-objects/customs/${$(this).data('name')}`;
+                    window.open(url);
+                });
             });
         }
 
@@ -698,7 +710,7 @@
             <div class="div-entities">
                 <table>
                     <thead>
-                        <tr><th>Entity ID</th><th>States</th><th class="attributes">Attributes</th></tr>
+                        <tr><th></th><th>Entity ID</th><th>States</th><th class="attributes">Attributes</th></tr>
                     </thead>
                     <tbody id="entities">
 

--- a/admin/index_m.html
+++ b/admin/index_m.html
@@ -110,12 +110,26 @@
                     text += '<td class="entity-id" title="' + click2copy + '">' + list[i].entity_id + '</td>';
                     text += '<td>' + formatIds(list[i].context.STATE) + '</td><td class="attributes">';
 
-                    if (list[i].context.ATTRIBUTES) {
+                    if (list[i].attributes || list[i].context.ATTRIBUTES) {
                         var attrs = [];
-                        list[i].context.ATTRIBUTES.forEach(function (attr) {
-                            attrs.push('<b>' + attr.attribute + '</b>: ' + formatIds(attr));
-                        });
-                        text += attrs.join('<br>');
+                        var keysList = [];
+
+                        if (list[i].context.ATTRIBUTES) {
+                            list[i].context.ATTRIBUTES.forEach(function (attr) {
+                                attrs.push('<b>' + attr.attribute + '</b>: ' + formatIds(attr));
+                                keysList.push(attr.attribute);
+                            });
+                        }
+
+                        if (list[i].attributes) {
+                            for (var key in list[i].attributes) {
+                                let attribute = '<b>' + key + '</b>: ' + list[i].attributes[key];
+                                if (!keysList.includes(key)) {
+                                    attrs.push('<b>' + key + '</b>: ' + list[i].attributes[key]);
+                                }
+                            }
+                        }
+                        text += attrs.sort().join('<br>');
                     }
                     text += '</td></tr>';
                 }

--- a/lib/server.js
+++ b/lib/server.js
@@ -1045,18 +1045,17 @@ class WebServer {
                         // ON
                         this.adapter.setForeignState(entity.context.STATE.setId, true, false, {user}, () => {
                             // If dimmer level set
-                            if (data.service_data.brightness_pct !== undefined) {
-                                this.adapter.setForeignState(command.setId, data.service_data.brightness_pct, false, {user}, err =>
+                            if (data.data_servivce.brightness_pct !== undefined) {
+                                this.adapter.setForeignState(command.setId, data.data_servivce.brightness_pct, false, {user}, err =>
                                     err ? reject(err) : resolve());
                             } else {
-                                this.adapter.setForeignState(command.setId, command.on, false, {user}, err =>
-                                    err ? reject(err) : resolve());
+                                resolve();
                             }
                         });
                     } else
                     // If dimmer level set
-                    if (data.service_data.brightness_pct !== undefined) {
-                        this.adapter.setForeignState(command.setId, data.service_data.brightness_pct, false, {user}, err =>
+                    if (data.data_servivce.brightness_pct !== undefined) {
+                        this.adapter.setForeignState(command.setId, data.data_servivce.brightness_pct, false, {user}, err =>
                             err ? reject(err) : resolve());
                     } else {
                         resolve();
@@ -1064,8 +1063,8 @@ class WebServer {
                 });
             } else
             // If dimmer level set
-            if (data.service_data.brightness_pct !== undefined) {
-                this.adapter.setForeignState(command.setId, data.service_data.brightness_pct, false, {user}, err =>
+            if (data.data_servivce.brightness_pct !== undefined) {
+                this.adapter.setForeignState(command.setId, data.data_servivce.brightness_pct, false, {user}, err =>
                     err ? reject(err) : resolve());
             } else {
                 resolve();
@@ -1103,7 +1102,6 @@ class WebServer {
             entity.context.COMMANDS = [{
                 service: 'turn_on',
                 setId: state.id,
-                on: obj.common.max || 100,
                 parseCommand: this._parseCommandDimmer.bind(this)
             }];
             this._addID2entity(state.id, entity);
@@ -1325,10 +1323,9 @@ class WebServer {
                     entity.context.COMMANDS = [{
                         service: 'turn_on',
                         setId: id,
-                        on: obj.common.max || 100,
                         parseCommand: this._parseCommandDimmer.bind(this)
-                    },
-                    {
+                    }];
+                    entity.context.COMMANDS = [{
                         service: 'turn_off',
                         setId: id,
                         off: obj.common.min || 0,

--- a/lib/server.js
+++ b/lib/server.js
@@ -1317,6 +1317,7 @@ class WebServer {
             const entity = this._processCommon(id, null, null, null, obj, entityType, entityType + '.' + name);
 
             entity.context.STATE = {getId: id, setId: id};
+            entity.isManual = true;
 
             if (entityType === 'light') {
                 if (obj.common.type === 'number') {

--- a/lib/server.js
+++ b/lib/server.js
@@ -1045,17 +1045,18 @@ class WebServer {
                         // ON
                         this.adapter.setForeignState(entity.context.STATE.setId, true, false, {user}, () => {
                             // If dimmer level set
-                            if (data.data_servivce.brightness_pct !== undefined) {
-                                this.adapter.setForeignState(command.setId, data.data_servivce.brightness_pct, false, {user}, err =>
+                            if (data.service_data.brightness_pct !== undefined) {
+                                this.adapter.setForeignState(command.setId, data.service_data.brightness_pct, false, {user}, err =>
                                     err ? reject(err) : resolve());
                             } else {
-                                resolve();
+                                this.adapter.setForeignState(command.setId, command.on, false, {user}, err =>
+                                    err ? reject(err) : resolve());
                             }
                         });
                     } else
                     // If dimmer level set
-                    if (data.data_servivce.brightness_pct !== undefined) {
-                        this.adapter.setForeignState(command.setId, data.data_servivce.brightness_pct, false, {user}, err =>
+                    if (data.service_data.brightness_pct !== undefined) {
+                        this.adapter.setForeignState(command.setId, data.service_data.brightness_pct, false, {user}, err =>
                             err ? reject(err) : resolve());
                     } else {
                         resolve();
@@ -1063,8 +1064,8 @@ class WebServer {
                 });
             } else
             // If dimmer level set
-            if (data.data_servivce.brightness_pct !== undefined) {
-                this.adapter.setForeignState(command.setId, data.data_servivce.brightness_pct, false, {user}, err =>
+            if (data.service_data.brightness_pct !== undefined) {
+                this.adapter.setForeignState(command.setId, data.service_data.brightness_pct, false, {user}, err =>
                     err ? reject(err) : resolve());
             } else {
                 resolve();
@@ -1102,6 +1103,7 @@ class WebServer {
             entity.context.COMMANDS = [{
                 service: 'turn_on',
                 setId: state.id,
+                on: obj.common.max || 100,
                 parseCommand: this._parseCommandDimmer.bind(this)
             }];
             this._addID2entity(state.id, entity);
@@ -1323,9 +1325,10 @@ class WebServer {
                     entity.context.COMMANDS = [{
                         service: 'turn_on',
                         setId: id,
+                        on: obj.common.max || 100,
                         parseCommand: this._parseCommandDimmer.bind(this)
-                    }];
-                    entity.context.COMMANDS = [{
+                    },
+                    {
                         service: 'turn_off',
                         setId: id,
                         off: obj.common.min || 0,


### PR DESCRIPTION
Added a button to table on tab 'Entities' to open the custom settings of manually defined objects directly from the adapter settings. Very useful if you a have a large number of manually defined objects

![grafik](https://user-images.githubusercontent.com/6370451/63778695-9686e680-c8e5-11e9-8a6d-1bb5adbe5d51.png)
