### PR TITLE
add support for color temperature

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -170,6 +170,7 @@ class WebServer {
             [Types.socket]:                 this._processSocket.bind(this),
             [Types.light]:                  this._processLight.bind(this),
             [Types.dimmer]:                 this._processDimmer.bind(this),
+            [Types.ct]:                     this._processColorTemperature.bind(this),
             [Types.motion]:                 this._processMotion.bind(this),
             [Types.window]:                 this._processWindow.bind(this),
             [Types.door]:                   this._processDoor.bind(this),
@@ -1364,6 +1365,68 @@ class WebServer {
 
         return [entity];
     }
+
+    _processColorTemperature(id, control, name, room, func, _obj) {
+        const entity = this._processDimmer(id, control, name,room, func, _obj)[0];
+
+
+        const iobMaxValue = 153;
+        const iobMinValue = 450;
+
+        if (!entity.context.STATE || !entity.context.STATE.setId) {
+            let state = control.states.find(s => s.id && s.name === 'ON');
+            if (!state) {
+                state = control.states.find(s => s.id && s.name === 'SET');
+            }
+            entity.context.STATE = {setId: null, getId: null};
+            if (state && state.id) {
+                entity.context.STATE.setId = state.id;
+                entity.context.STATE.getId = state.id;
+                this._addID2entity(state.id, entity);
+            }
+        }
+
+        const temperature = control.states.find(s => s.id && s.name === 'TEMPERATURE');
+        if (temperature && temperature.id) {
+            entity.context.ATTRIBUTES = [{attribute: 'color_temp', getId: temperature.id}];
+            entity.attributes.supported_features |= 0x02;
+            entity.attributes.color_temp = 150;
+            this.adapter.getForeignObject(temperature.id, (err, obj) => {
+                if (err) {
+                    throw err;
+                }
+                if (obj.common.unit === 'K') {
+                    this.adapter.log.debug('Kelvin -> need to do mired conversion');
+                    entity.attributes.iob_convert_kelvin = true;
+                }
+                if (obj.common.max) {
+                    if (entity.attributes.iob_convert_kelvin || obj.common.max > 1000) { //probably kelvin in this case.
+                        entity.attributes.iob_convert_kelvin = true;
+                        entity.attributes.mired_max = 1e6 / obj.common.max;
+                    } else {
+                        entity.attributes.mired_max = obj.common.max;
+                    }
+                } else {
+                    entity.attributes.mired_max = iobMaxValue;
+                    this.adapter.log.warn(`no max value for light object '${id}' defined -> using fallback max = '${iobMaxValue}'`);
+                }
+                if (obj.common.min) {
+                    if (entity.attributes.iob_convert_kelvin || obj.common.min > 1000) { //probably kelvin in this case.
+                        entity.attributes.iob_convert_kelvin = true;
+                        entity.attributes.mired_min = 1e6 / obj.common.min;
+                    } else {
+                        entity.attributes.mired_min = obj.common.min;
+                    }
+                } else {
+                    entity.attributes.mired_min = iobMinValue;
+                    this.adapter.log.warn(`no min value for light object '${id}' defined -> using fallback max = '${iobMinValue}'`);
+                }
+            });
+        }
+
+        if (id.indexOf('Bad_Oben') >= 0) {
+            this.log.debug('Result entity: ' + JSON.stringify(entity, null, 2));
+        }
 
     _processDoor(id, control, name, room, func, _obj, objects) {
         const entity = this._processCommon(id, name, room, func, _obj, 'binary_sensor');

--- a/lib/server.js
+++ b/lib/server.js
@@ -1366,7 +1366,33 @@ class WebServer {
         return [entity];
     }
 
-    _processColorTemperature(id, control, name, room, func, _obj) {
+    _parseCommandTemperature(entity, command, data, user) {
+        return new Promise((resolve, reject) => {
+            if (data.service_data.color_temp) {
+                let ct = data.service_data.color_temp;
+                let attr = entity.context.ATTRIBUTES.find(a => a.attribute === 'color_temp');
+                if (!attr) {
+                    this.log.error('Could not find attribute for color_temp!');
+                    attr = {convert_to_kelvin: ct > 1000};
+                }
+                if (attr.convert_to_kelvin) {
+                    ct = 1e6 / ct;
+                }
+                if (command.setId.indexOf('Bad') >= 0) {
+                    this.log.debug('In val ' + ct + ' converted to ' + ct);
+                }
+                //turn on lamp - why do I have to do this myself?
+                this.adapter.setForeignState(data.id, true, false, {user}, () =>
+                    this.adapter.setForeignState(command.setId, ct, false, {user}, err =>
+                        err ? reject(err) : resolve()));
+            } else {
+                this.adapter.setForeignState(data.id, true, false, {user}, () =>
+                    resolve());
+            }
+        });
+    }
+
+    _processColorTemperature(id, control, name, room, func, _obj, objects) {
         const entity = this._processDimmer(id, control, name,room, func, _obj)[0];
 
 
@@ -1388,45 +1414,70 @@ class WebServer {
 
         const temperature = control.states.find(s => s.id && s.name === 'TEMPERATURE');
         if (temperature && temperature.id) {
-            entity.context.ATTRIBUTES = [{attribute: 'color_temp', getId: temperature.id}];
+            const tempObj = objects[temperature.id];
+            const attribute = {
+                attribute: 'color_temp',
+                getId: temperature.id,
+                setId: temperature.id,
+                convert_to_kelvin: false,
+                getParser: function (entity, attr, state) {
+                    if (!state || !state.val) {
+                        entity.attributes.color_temp = 'unknown';
+                        return;
+                    }
+                    let targetCt = state.val;
+                    if (attr.convert_to_kelvin) {
+                        targetCt = 1e6 / targetCt;
+                    }
+                    entity.attributes.color_temp = targetCt;
+                }.bind(this)
+            };
+
+            if (tempObj.common.unit === 'K') {
+                attribute.convert_to_kelvin = true;
+            }
+            if (tempObj.common.max) {
+                if (entity.attributes.iob_convert_kelvin || tempObj.common.max > 1000) { //probably kelvin in this case.
+                    attribute.convert_to_kelvin = true;
+                    entity.attributes.max_mireds = 1e6 / tempObj.common.max;
+                } else {
+                    entity.attributes.max_mireds = tempObj.common.max;
+                }
+            } else {
+                entity.attributes.max_mireds = iobMaxValue;
+                this.adapter.log.warn(`no max value for light object '${id}' defined -> using fallback max = '${iobMaxValue}'`);
+            }
+            if (tempObj.common.min) {
+                if (entity.attributes.iob_convert_kelvin || tempObj.common.min > 1000) { //probably kelvin in this case.
+                    attribute.convert_to_kelvin = true;
+                    entity.attributes.min_mireds = 1e6 / tempObj.common.min;
+                } else {
+                    entity.attributes.min_mireds = tempObj.common.min;
+                }
+            } else {
+                entity.attributes.min_mireds = iobMinValue;
+                this.adapter.log.warn(`no min value for light object '${id}' defined -> using fallback max = '${iobMinValue}'`);
+            }
+
+            if (!entity.context.ATTRIBUTES) {
+                entity.context.ATTRIBUTES = [];
+            }
+            entity.context.ATTRIBUTES.push(attribute);
             entity.attributes.supported_features |= 0x02;
-            entity.attributes.color_temp = 150;
-            this.adapter.getForeignObject(temperature.id, (err, obj) => {
-                if (err) {
-                    throw err;
-                }
-                if (obj.common.unit === 'K') {
-                    this.adapter.log.debug('Kelvin -> need to do mired conversion');
-                    entity.attributes.iob_convert_kelvin = true;
-                }
-                if (obj.common.max) {
-                    if (entity.attributes.iob_convert_kelvin || obj.common.max > 1000) { //probably kelvin in this case.
-                        entity.attributes.iob_convert_kelvin = true;
-                        entity.attributes.mired_max = 1e6 / obj.common.max;
-                    } else {
-                        entity.attributes.mired_max = obj.common.max;
-                    }
-                } else {
-                    entity.attributes.mired_max = iobMaxValue;
-                    this.adapter.log.warn(`no max value for light object '${id}' defined -> using fallback max = '${iobMaxValue}'`);
-                }
-                if (obj.common.min) {
-                    if (entity.attributes.iob_convert_kelvin || obj.common.min > 1000) { //probably kelvin in this case.
-                        entity.attributes.iob_convert_kelvin = true;
-                        entity.attributes.mired_min = 1e6 / obj.common.min;
-                    } else {
-                        entity.attributes.mired_min = obj.common.min;
-                    }
-                } else {
-                    entity.attributes.mired_min = iobMinValue;
-                    this.adapter.log.warn(`no min value for light object '${id}' defined -> using fallback max = '${iobMinValue}'`);
-                }
-            });
+
+            //necessary to really set color_temp in ioBroker. Hm. Why?
+            entity.context.COMMANDS = [{
+                service: 'turn_on',
+                setId: temperature.id,
+                parseCommand: this._parseCommandTemperature.bind(this)
+            }];
+
+            entity.attributes.color_temp = entity.attributes.mired_min; //set min for a start.
+            this._addID2entity(temperature.id, entity);
         }
 
-        if (id.indexOf('Bad_Oben') >= 0) {
-            this.log.debug('Result entity: ' + JSON.stringify(entity, null, 2));
-        }
+        return [entity];
+    }
 
     _processDoor(id, control, name, room, func, _obj, objects) {
         const entity = this._processCommon(id, name, room, func, _obj, 'binary_sensor');

--- a/lib/server.js
+++ b/lib/server.js
@@ -1367,27 +1367,56 @@ class WebServer {
     }
 
     _parseCommandTemperature(entity, command, data, user) {
-        return new Promise((resolve, reject) => {
+        const adapter = this.adapter;
+        function setCt(resolve, reject) {
             if (data.service_data.color_temp) {
                 let ct = data.service_data.color_temp;
                 let attr = entity.context.ATTRIBUTES.find(a => a.attribute === 'color_temp');
                 if (!attr) {
-                    this.log.error('Could not find attribute for color_temp!');
+                    adapter.log.error('Could not find attribute for color_temp!');
                     attr = {convert_to_kelvin: ct > 1000};
                 }
                 if (attr.convert_to_kelvin) {
                     ct = 1e6 / ct;
                 }
                 if (command.setId.indexOf('Bad') >= 0) {
-                    this.log.debug('In val ' + ct + ' converted to ' + ct);
+                    adapter.log.debug('In val ' + ct + ' converted to ' + ct);
                 }
-                //turn on lamp - why do I have to do this myself?
-                this.adapter.setForeignState(data.id, true, false, {user}, () =>
-                    this.adapter.setForeignState(command.setId, ct, false, {user}, err =>
-                        err ? reject(err) : resolve()));
+
+                adapter.setForeignState(command.setId, ct, false, {user}, err =>
+                    err ? reject(err) : resolve());
             } else {
-                this.adapter.setForeignState(data.id, true, false, {user}, () =>
-                    resolve());
+                adapter.log.debug('No Ct in service call -> only turn on.');
+                resolve();
+            }
+        }
+
+        return new Promise((resolve, reject) => {
+            // if ON/OFF object exists
+            if (entity.context.STATE.setId && entity.context.STATE.getId) {
+                // read actual state
+                const ids = [];
+                ids.push(entity.context.STATE.getId);
+                //get colorTemp value if exists
+                const colorTemp = entity.context.ATTRIBUTES.map(entry =>
+                    entry.attribute === 'color_temp' ? entry.setId : '');
+
+                if (colorTemp && colorTemp.length) {
+                    ids.push(colorTemp[0]);
+                }
+
+                //const gIds = ids;
+                this.adapter.getForeignStates(ids, {user}, (err, state) => {
+                    // if lamp is not ON
+                    if (!state[entity.context.STATE.getId] || !state[entity.context.STATE.getId].val) {
+                        // turn ON:
+                        this.adapter.setForeignState(entity.context.STATE.setId, true, false, {user}, () => setCt(resolve, reject));
+                    } else {
+                        setCt(resolve, reject);
+                    }
+                });
+            } else {
+                setCt(resolve, reject);
             }
         });
     }


### PR DESCRIPTION
This code adds support for color temperature in current architecture.

Somehow most of my lamps are identified as "ct", which was rejected before this code. But they can also dim... with this code dimming from lovelace of these lamps still is not possible. If I understand it correctly, I'd have to duplicate the brightness handling in the color processing code. Did I understand that correct? Or is something wrong with my devices?

I added the line "processDimmer" in the [top of my function](https://github.com/Garfonso/ioBroker.lovelace/blob/master/lib/server.js#L1425). This will not show any useful result above processCommon with my devices, because the processDimmer function looks for states (ON_SET, ON_ACTUAL, ACTUAL, SET) that are not in the controls I get in the ct-device at all. Why is that so? Where do they come from? Can I "convert" what I got so that processDimmer can handle it? But that would probably break my code, because there can only be one turn_on handler, right? ([this])(https://github.com/ioBroker/ioBroker.lovelace/blob/master/lib/server.js#L1721). So Probably the only way currently is for the ct function to handle brightness, too? What will happen if I look into hue?

There are probably very good reasons for the current architecture and I'd really like to hear them. And maybe you have an idea how to easily integrate the brightness handling into a ct device without too much code duplication, I'd be happy to add that.
Or you can just merge. I'm fine with that too. 😄 (and maybe discuss architecture later)