### PR TITLE
Add support for white value

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -1371,6 +1371,11 @@ class WebServer {
             }
             return;
         }
+        if (data.service_data.white_value) {
+            const attr = entity.context.ATTRIBUTES.find(a => a.attribute === 'white_value');
+            this.adapter.setForeignState(attr.setId, data.service_data.white_value / 255 * attr.max, false, {user}, err => err ? reject(err) : resolve());
+            return;
+        }
         this.adapter.log.debug('No additional data in service call -> only turn on.');
         resolve();
     }
@@ -1653,6 +1658,7 @@ class WebServer {
         const redState = control.states.find(s => s.id && s.name === 'RED');
         const greenState = control.states.find(s => s.id && s.name === 'GREEN');
         const blueState = control.states.find(s => s.id && s.name === 'BLUE');
+        const whiteState = control.states.find(s => s.id && s.name === 'WHITE');
         if (redState && redState.id && greenState && greenState.id && blueState && blueState.id) {
             //create main attribute for red:
             const attribute = {
@@ -1713,6 +1719,23 @@ class WebServer {
             this._addID2entity(redState.id, entity);
             this._addID2entity(greenState.id, entity);
             this._addID2entity(blueState.id, entity);
+
+            if (whiteState && whiteState.id) {
+                const whiteAttribute = {
+                    attribute: 'white_value',
+                    getId: whiteState.id,
+                    setId: whiteState.id,
+                    max: objects[whiteState.id].common.max || 100,
+                    getParser: (entity, attr, state) => {
+                        state = state || {val: 0};
+                        entity.attributes.white_value = state.val / attr.max * 255;
+                    }
+                };
+                entity.context.ATTRIBUTES.push(whiteAttribute);
+                entity.attributes.supported_features |= 0x80;
+                entity.attributes.white_value = 0;
+                this._addID2entity(whiteState.id, entity);
+            }
         }
     }
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -1371,7 +1371,7 @@ class WebServer {
             }
             return;
         }
-        if (data.service_data.white_value) {
+        if (data.service_data.white_value >= 0) {
             const attr = entity.context.ATTRIBUTES.find(a => a.attribute === 'white_value');
             this.adapter.setForeignState(attr.setId, data.service_data.white_value / 255 * attr.max, false, {user}, err => err ? reject(err) : resolve());
             return;

--- a/lib/server.js
+++ b/lib/server.js
@@ -1304,7 +1304,7 @@ class WebServer {
             return hex;
         }
 
-        if (data.service_data.color_temp) {
+        if (data.service_data.color_temp) { //will also be false for ct = 0 -> but ct = 0 is not a useful mired value and creates issues with the conversion.
             let ct = data.service_data.color_temp;
             entity.attributes.color_temp = ct;
             const attr = entity.context.ATTRIBUTES.find(a => a.attribute === 'color_temp');


### PR DESCRIPTION
white value is supported by some shelly lamps. A guy in the forum did test this and it is ok now. 