### PR TITLE
started refactoring sever.js

### DIFF
--- a/lib/converters/switch.js
+++ b/lib/converters/switch.js
@@ -1,0 +1,24 @@
+const {Types} = require('iobroker.type-detector');
+
+exports.processSocket = function (id, control, name, room, func, _obj) {
+    const entity = this._processCommon(name, room, func, _obj, 'switch');
+
+    let state = control.states.find(s => s.id && s.name === 'SET');
+    entity.context.STATE = {setId: null, getId: null};
+    if (state && state.id) {
+        entity.context.STATE.setId = state.id;
+        entity.context.STATE.getId = state.id;
+        if (control.type === Types.socket) {
+            entity.attributes.icon = 'mdi:power-socket-eu';
+        }
+        this._addID2entity(state.id, entity);
+    }
+
+    state = control.states.find(s => s.id && s.name === 'ACTUAL');
+    if (state && state.id) {
+        entity.context.STATE.getId = state.id;
+        this._addID2entity(state.id, entity);
+    }
+
+    return [entity];
+};

--- a/lib/converters/switch.test.js
+++ b/lib/converters/switch.test.js
@@ -1,0 +1,126 @@
+const _processSocket = require('./switch').processSocket;
+const {Types} = require('iobroker.type-detector');
+
+const expect = require('chai').expect;
+const sinon = require('sinon');
+
+const mockServer = {
+    _processCommon: function () {
+        return {
+            entity_id: 'switch.entity_id',
+            attributes: {
+                friendly_name: 'Name'
+            },
+            context: {
+                id: 'iobroker.0.id',
+                type: 'switch'
+            }
+        };
+    },
+    _addID2entity: function () {}
+};
+const processSocket = _processSocket.bind(mockServer);
+
+describe('converters/switch', function () {
+    it('socket', function () {
+        const id = 'test.socket';
+        const control = {
+            type: Types.socket,
+            states: [
+                {
+                    indicator: false, type: 'boolean', name: 'SET', required: true, write: true, defaultRole: 'switch', id: 'test.socket.state'
+                },
+                {
+                    indicator: false, type: 'boolean', name: 'ACTUAL', required: true, write: false, defaultRole: 'switch'
+                }
+            ]
+        };
+        const _obj = {
+            type: 'device',
+            common: {
+                name: 'Some Socket'
+            },
+            native: {},
+            _id: id
+        };
+
+        const mock = sinon.mock(mockServer);
+        mock.expects('_addID2entity').once().withArgs(control.states[0].id);
+
+        const entities = processSocket(id,control, null, null, null, _obj);
+        expect(entities).to.have.lengthOf(1);
+        const entity = entities[0];
+        expect(entity).to.have.nested.property('attributes.icon', 'mdi:power-socket-eu');
+        expect(entity).to.have.nested.property('context.STATE');
+        expect(entity).to.have.nested.property('context.STATE.setId', control.states[0].id);
+        expect(entity).to.have.nested.property('context.STATE.getId', control.states[0].id);
+        mock.verify();
+    });
+
+    it('socket with ACTUAL', function () {
+        const id = 'test.socket';
+        const control = {
+            type: Types.socket,
+            states: [
+                {
+                    indicator: false, type: 'boolean', name: 'SET', required: true, write: true, defaultRole: 'switch', id: 'test.socket.state'
+                },
+                {
+                    indicator: false, type: 'boolean', name: 'ACTUAL', required: true, write: false, defaultRole: 'switch', id: 'test.socket.readState'
+                }
+            ]
+        };
+        const _obj = {
+            type: 'device',
+            common: {
+                name: 'Some Socket'
+            },
+            native: {},
+            _id: id
+        };
+
+        const mock = sinon.mock(mockServer);
+        mock.expects('_addID2entity').once().withArgs(control.states[0].id);
+        mock.expects('_addID2entity').once().withArgs(control.states[1].id);
+
+        const entities = processSocket(id,control, null, null, null, _obj);
+        expect(entities).to.have.lengthOf(1);
+        const entity = entities[0];
+        expect(entity).to.have.nested.property('attributes.icon', 'mdi:power-socket-eu');
+        expect(entity).to.have.nested.property('context.STATE');
+        expect(entity).to.have.nested.property('context.STATE.setId', control.states[0].id);
+        expect(entity).to.have.nested.property('context.STATE.getId', control.states[1].id);
+        mock.verify();
+    });
+
+    it('button', function () {
+        const id = 'test.button';
+        const control = {
+            type: Types.button,
+            states: [
+                {
+                    indicator: false, type: 'boolean', name: 'SET', required: true, write: true, defaultRole: 'switch', id: 'test.button.state'
+                }
+            ]
+        };
+        const _obj = {
+            type: 'device',
+            common: {
+                name: 'Some Button'
+            },
+            native: {},
+            _id: id
+        };
+
+        const mock = sinon.mock(mockServer);
+        mock.expects('_addID2entity').once().withArgs(control.states[0].id);
+
+        const entities = processSocket(id,control, null, null, null, _obj);
+        expect(entities).to.have.lengthOf(1);
+        const entity = entities[0];
+        expect(entity).to.not.have.nested.property('attributes.icon');
+        expect(entity).to.have.nested.property('context.STATE');
+        expect(entity).to.have.nested.property('context.STATE.setId', control.states[0].id);
+        mock.verify();
+    });
+});

--- a/lib/converters/utils.js
+++ b/lib/converters/utils.js
@@ -1,0 +1,180 @@
+const pinyin = require('pinyin');
+
+/**
+ * Replaces invalid characters from generated unique part of entity id, i.e. light.idPart
+ * @param idPart unique part of entity Id
+ * @returns {string} cleaned entity Id part.
+ */
+function replaceInvalidChars(idPart) {
+    idPart = idPart.replace(/Ü/g, 'UE');
+    idPart = idPart.replace(/Ä/g, 'AE');
+    idPart = idPart.replace(/Ö/g, 'OE');
+    idPart = idPart.replace(/ü/g, 'ue');
+    idPart = idPart.replace(/ä/g, 'ae');
+    idPart = idPart.replace(/ö/g, 'oe');
+    idPart = idPart.replace(/ß/g, 'ss');
+    idPart = idPart.replace(/[^a-zA-Z0-9А-Яа-я_]/g, '_');
+    return idPart;
+}
+
+function getObjectIcon(obj, prefix) {
+    prefix = prefix || '.';//http://localhost:8081';
+
+    if (!obj || !obj.common || !obj.common.icon) {
+        return null;
+    }
+
+    let icon;
+    if (!obj.common.icon.match(/^data:image\//)) {
+        if (obj.common.icon.indexOf('.') !== -1) {
+            let instance;
+            if (obj.type === 'instance') {
+                icon = prefix + '/adapter/' + obj.common.name + '/' + obj.common.icon;
+            } else if (obj._id && obj._id.match(/^system\.adapter\./)) {
+                instance = obj._id.split('.', 3);
+                if (obj.common.icon[0] === '/') {
+                    instance[2] += obj.common.icon;
+                } else {
+                    instance[2] += '/' + obj.common.icon;
+                }
+                icon = prefix + '/adapter/' + instance[2];
+            } else {
+                instance = obj._id.split('.', 2);
+                if (obj.common.icon[0] === '/') {
+                    instance[0] += obj.common.icon;
+                } else {
+                    instance[0] += '/' + obj.common.icon;
+                }
+                icon = prefix + '/adapter/' + instance[0];
+            }
+        } else {
+            return null; // '<i class="material-icons iob-list-icon">' + obj.common.icon + '</i>';
+        }
+    } else {
+        // base 64 image
+        icon = obj.common.icon;
+    }
+
+    return icon;
+}
+
+/**
+ * ioBroker ID needs to be subscribed, if entity is used in vis in order to update.
+ * @param id of ioBroker object
+ * @param entity entity_id
+ */
+function _addID2entity(id, entity) {
+    this._ID2entity[id] = this._ID2entity[id] || [];
+    const found = this._ID2entity[id].find(e => e.entity_id === entity.entity_id);
+    if (!found) {
+        this._ID2entity[id].push(entity);
+    }
+}
+
+function _getObjectName(obj, _lang) {
+    //_lang = _lang || this.lang; can't do this. Make sure lang is set below.
+
+    if (obj && obj.common && obj.common.name) {
+        if (typeof obj.common.name === 'object') {
+            if (obj.common.name[_lang] || obj.common.name.en) {
+                return obj.common.name[_lang] || obj.common.name.en;
+            } else {
+                const lang = Object.keys(obj.common.name).find(lang => obj.common.name[lang]);
+                if (obj.common.name[lang]) {
+                    return obj.common.name[lang];
+                } else {
+                    return obj._id;
+                }
+            }
+        } else {
+            return obj.common.name;
+        }
+    } else {
+        return obj ? obj._id || '' : '';
+    }
+}
+
+function getObjectName(obj, __lang) {
+    const objName = _getObjectName(obj, __lang);
+    const pinyinObjNameObj = pinyin(objName, {style: pinyin.STYLE_TONE2});
+    if (typeof pinyinObjNameObj === 'object' && pinyinObjNameObj.length > 1) {
+        // Found Chinese word.
+        // "Chinese中文" => [ [ 'Chinese' ], [ 'zhong1' ], [ 'wen2' ] ]
+        let pinyinObjName = '';
+        for (let i = 0; i < pinyinObjNameObj.length; i++) {
+            if (typeof pinyinObjNameObj[i] === 'object') {
+                pinyinObjName += pinyinObjNameObj[i][0];
+            }
+        }
+        return pinyinObjName;
+    }
+    // No Chinese word found, return origin object name
+    return objName;
+}
+
+function generateName(obj, lang) {
+    return getObjectName(obj, lang).replace(/[^-._\w0-9А-Яа-яÄÜÖßäöü ]/g, '_');
+}
+
+/**
+ * generate a bare entity from parameters. Already adds the entity to a bunch of arrays. So be sure to use it!
+ * @param {string|null} name friendly name of entity, if empty, will be read from object or generated from room & func or id.
+ * @param {string|null} room room of device for name generation
+ * @param {string|null} func function of device for name generation
+ * @param {Object} obj ioBroker object, used to read id, name, icon, unit, lovelace specific settings.
+ * @param {string} entityType lovelace domain of entity, for example light, sensor, ...
+ * @param [entity_id] predefined entity id. If empty, will be generated from name
+ * @returns {{context: {id: string, type: string}, attributes: {friendly_name: string}, entity_id: string}}
+ */
+function _processCommon(name, room, func, obj, entityType, entity_id) {
+    if (!name) {
+        if (obj && obj.common && obj.common.name) {
+            name = generateName(obj, this.lang);
+        } else if (func && room) {
+            name = room + ' ' + func;
+        } else {
+            name = (obj && obj.common && obj.common.custom && obj.common.custom[this.adapter.namespace] && obj.common.custom[this.adapter.namespace].name) || generateName(obj, this.lang);
+        }
+    }
+    const idPart = replaceInvalidChars(generateName(obj, 'en'));
+
+    const entity = {
+        entity_id: entity_id || (entityType + '.' + idPart),
+        attributes: {
+            friendly_name: name
+        },
+        //last_changed: new Date(state.lc).toISOString(),
+        //last_updated: new Date(state.ts).toISOString(),
+        context: {
+            id: obj._id,
+            type: entityType,
+        }
+    };
+
+    if (obj.common.unit) {
+        entity.attributes.unit_of_measurement = obj.common.unit;
+        //entity.attributes.unit_of_measurement_dict = obj.common.unit;
+    }
+
+    if (obj.common.icon) {
+        entity.attributes.entity_picture = getObjectIcon(obj);
+    }
+
+    this._ID2entity[obj._id] = this._ID2entity[obj._id] || [];
+    this._addID2entity(obj._id, entity);
+    this._entity2ID[entity.entity_id] = entity;
+    const foundIndex = this._entities.findIndex(x => x.entity_id === entity.entity_id);
+    if (foundIndex !== -1) {
+        this._entities[foundIndex] = entity;
+    } else {
+        this._entities.push(entity);
+    }
+    return entity;
+}
+
+//required to read user name
+exports.getObjectName       = getObjectName;
+
+//required by other converters:
+exports._processCommon       = _processCommon;
+exports._addID2entity        = _addID2entity;

--- a/lib/converters/utils.test.js
+++ b/lib/converters/utils.test.js
@@ -1,0 +1,100 @@
+const expect = require('chai').expect;
+
+const utils = require('./utils');
+
+const mockServer = {
+    _entities     : [],
+    _entity2ID    : {},
+    _ID2entity    : {},
+    land          : 'en',
+    adapter       : { namespace: 'lovelace.1' }
+};
+const _processCommon = utils._processCommon.bind(mockServer);
+mockServer._addID2entity  = utils._addID2entity.bind(mockServer);
+
+function expectEntity(entity, entity_id, id, name, type) {
+    expect(entity).to.have.property('entity_id', entity_id);
+    expect(entity).to.have.property('attributes');
+    expect(entity).to.have.nested.property('attributes.friendly_name', name);
+    expect(entity).to.have.property('context');
+    expect(entity).to.have.nested.property('context.id', id);
+    expect(entity).to.have.nested.property('context.type', type);
+    expect(mockServer._ID2entity).to.have.property(id);
+    expect(mockServer._entity2ID).to.have.property(entity_id);
+
+}
+
+describe('converters/utils', function () {
+    it('processCommon -> id from common.name', function () {
+        const id = 'test.0.socket';
+        const entity_id = 'switch.Some_Socket';
+        const obj = {
+            type: 'device',
+            common: {
+                name: 'Some Socket'
+            },
+            native: {},
+            _id: id
+        };
+        const currLength = mockServer._entities.length;
+        const entity = _processCommon(null, null, null, obj, 'switch');
+        expectEntity(entity, entity_id, id, obj.common.name, 'switch');
+        expect(mockServer._entities).to.have.lengthOf(currLength + 1);
+    });
+
+    it('processCommon -> id from name argument', function () {
+        const id = 'test.0.other_socket';
+        const entity_id = 'switch.Some_other_Socket';
+        const name = 'Some other Socket';
+        const obj = {
+            type: 'device',
+            common: {
+                name: 'Some other Socket'
+            },
+            native: {},
+            _id: id
+        };
+        const currLength = mockServer._entities.length;
+
+        const entity = _processCommon(name, null, null, obj, 'switch');
+        expectEntity(entity, entity_id, id, name, 'switch');
+        expect(mockServer._entities).to.have.lengthOf(currLength + 1);
+    });
+
+    it('processCommon -> id from room & func', function () {
+        const id = 'test.0.light';
+        const entity_id = 'light.test_0_light'; //id is derived from object id.
+        const room = 'Room1';
+        const func = 'Light';
+        const obj = {
+            type: 'device',
+            common: {
+            },
+            native: {},
+            _id: id
+        };
+        const currLength = mockServer._entities.length;
+
+        const entity = _processCommon(null, room, func, obj, 'light');
+        expectEntity(entity, entity_id, id, 'Room1 Light', 'light');
+        expect(mockServer._entities).to.have.lengthOf(currLength + 1);
+    });
+
+    it('processCommon -> predefined id', function () {
+        const id = 'test.0.airCondition';
+        const entity_id = 'climate.Kitchen';
+        const obj = {
+            type: 'device',
+            common: {
+                name: 'AirCondition Kitchen'
+            },
+            native: {},
+            _id: id
+        };
+        const currLength = mockServer._entities.length;
+
+        const entity = _processCommon(null, null, null, obj, 'climate', entity_id);
+        expectEntity(entity, entity_id, id, obj.common.name, 'climate');
+        expect(mockServer._entities).to.have.lengthOf(currLength + 1);
+    });
+});

--- a/lib/server.js
+++ b/lib/server.js
@@ -8,8 +8,9 @@ const multer     = require('multer');
 const mime       = require('mime');
 const yaml       = require('js-yaml');
 const request    = require('request');
-const pinyin     = require('pinyin');
 const jstz       = require('jstimezonedetect');
+const utils      = require('./converters/utils');
+const processSocket = require('./converters/switch').processSocket;
 
 const bindings   = require('./bindings');
 
@@ -36,47 +37,6 @@ function getRootPath() {
     }
 }
 
-function getObjectIcon(obj, prefix) {
-    prefix = prefix || '.';//http://localhost:8081';
-
-    if (!obj || !obj.common || !obj.common.icon) {
-        return null;
-    }
-
-    let icon;
-    if (!obj.common.icon.match(/^data:image\//)) {
-        if (obj.common.icon.indexOf('.') !== -1) {
-            let instance;
-            if (obj.type === 'instance') {
-                icon = prefix + '/adapter/' + obj.common.name + '/' + obj.common.icon;
-            } else if (obj._id && obj._id.match(/^system\.adapter\./)) {
-                instance = obj._id.split('.', 3);
-                if (obj.common.icon[0] === '/') {
-                    instance[2] += obj.common.icon;
-                } else {
-                    instance[2] += '/' + obj.common.icon;
-                }
-                icon = prefix + '/adapter/' + instance[2];
-            } else {
-                instance = obj._id.split('.', 2);
-                if (obj.common.icon[0] === '/') {
-                    instance[0] += obj.common.icon;
-                } else {
-                    instance[0] += '/' + obj.common.icon;
-                }
-                icon = prefix + '/adapter/' + instance[0];
-            }
-        } else {
-            return null; // '<i class="material-icons iob-list-icon">' + obj.common.icon + '</i>';
-        }
-    } else {
-        // base 64 image
-        icon = obj.common.icon;
-    }
-
-    return icon;
-}
-
 const generateRandomToken = function (callback) {
     crypto.randomBytes(256, (ex, buffer) => {
         crypto.randomBytes(32, (ex, secret) => {
@@ -96,23 +56,6 @@ const generateRandomToken = function (callback) {
 
 function padding(num) {
     return num < 10 ? '0' + num : num;
-}
-
-/**
- * Replaces invalid characters from generated unique part of entity id, i.e. light.idPart
- * @param idPart unique part of entity Id
- * @returns {string} cleaned entity Id part.
- */
-function replaceInvalidChars(idPart) {
-    idPart = idPart.replace(/Ü/g, 'UE');
-    idPart = idPart.replace(/Ä/g, 'AE');
-    idPart = idPart.replace(/Ö/g, 'OE');
-    idPart = idPart.replace(/ü/g, 'ue');
-    idPart = idPart.replace(/ä/g, 'ae');
-    idPart = idPart.replace(/ö/g, 'oe');
-    idPart = idPart.replace(/ß/g, 'ss');
-    idPart = idPart.replace(/[^a-zA-Z0-9А-Яа-я_]/g, '_');
-    return idPart;
 }
 
 /*
@@ -175,9 +118,11 @@ class WebServer {
         this._app            = options.app;
         this._auth_flows     = {};
         this.templateStates  = {};
+        this._processCommon  = utils._processCommon.bind(this); //make processCommon operate on our members.
+        this._addID2entity   = utils._addID2entity.bind(this);  //make addID2entity operate on our members.
 
         this.converter = {
-            [Types.socket]:                 this._processSocket.bind(this),
+            [Types.socket]:                 processSocket.bind(this),
             [Types.light]:                  this._processLight.bind(this),
             [Types.dimmer]:                 this._processLightAdvanced.bind(this),
             [Types.ct]:                     this._processLightAdvanced.bind(this),
@@ -188,7 +133,7 @@ class WebServer {
             [Types.window]:                 this._processWindow.bind(this),
             [Types.windowTilt]:             this._processWindowTilt.bind(this),
             [Types.door]:                   this._processDoor.bind(this),
-            [Types.button]:                 this._processSocket.bind(this),
+            [Types.button]:                 processSocket.bind(this),
             [Types.temperature]:            this._processTemperature.bind(this),
             [Types.lock]:                   this._processLock.bind(this),
             [Types.thermostat]:             this._processThermostat.bind(this),
@@ -341,116 +286,10 @@ class WebServer {
         }
     }
 
-    _processCommon(id, name, room, func, obj, entityType, entity_id) {
-        if (!name) {
-            if (obj && obj.common && obj.common.name) {
-                name = this._generateName(obj);
-            } else if (func && room) {
-                name = room + ' ' + func;
-            } else {
-                name = (obj && obj.common && obj.common.custom && obj.common.custom[this.adapter.namespace] && obj.common.custom[this.adapter.namespace].name) || this._generateName(obj);
-            }
-        }
-        const idPart = replaceInvalidChars(this._generateName(obj, 'en'));
-
-        const entity = {
-            entity_id: entity_id || (entityType + '.' + idPart),
-            //state: this._iobState2EntityState(obj._id, state.val);
-            attributes: {
-                friendly_name: name
-            },
-            //last_changed: new Date(state.lc).toISOString(),
-            //last_updated: new Date(state.ts).toISOString(),
-            context: {
-                id: obj._id,
-                type: entityType,
-            }
-        };
-
-        if (obj.common.unit) {
-            entity.attributes.unit_of_measurement = obj.common.unit;
-            //entity.attributes.unit_of_measurement_dict = obj.common.unit;
-        }
-
-        if (obj.common.icon) {
-            entity.attributes.entity_picture = getObjectIcon(obj);
-        }
-
-        this._ID2entity[obj._id] = this._ID2entity[obj._id] || [];
-        this._addID2entity(obj._id, entity);
-        this._entity2ID[entity.entity_id] = entity;
-        const foundIndex = this._entities.findIndex(x => x.entity_id === entity.entity_id);
-        if (foundIndex !== -1) {
-            this._entities[foundIndex] = entity;
-        } else {
-            this._entities.push(entity);
-        }
-        return entity;
-    }
-
-    _addID2entity(id, entity) {
-        this._ID2entity[id] = this._ID2entity[id] || [];
-        const found = this._ID2entity[id].find(e => e.entity_id === entity.entity_id);
-        if (!found) {
-            this._ID2entity[id].push(entity);
-        }
-    }
-
     // ------------------------------- START OF CONVERTERS ---------------------------------------- //
 
-    _processSocket(id, control, name, room, func, _obj) {
-        const entity = this._processCommon(id, name, room, func, _obj, 'switch');
-
-        let state = control.states.find(s => s.id && s.name === 'SET');
-        entity.context.STATE = {setId: null, getId: null};
-        if (state && state.id) {
-            entity.context.STATE.setId = state.id;
-            entity.context.STATE.getId = state.id;
-            entity.attributes.icon = 'mdi:power-socket-eu';
-            this._addID2entity(state.id, entity);
-        }
-
-        state = control.states.find(s => s.id && s.name === 'ACTUAL');
-        if (state && state.id) {
-            entity.context.STATE.getId = state.id;
-            this._addID2entity(state.id, entity);
-        }
-        /*
-        this.adapter.getForeignState(entity.context.STATE.getId, (err, state) => {
-            console.log(JSON.stringify(entity));
-            entity.attributes.is_on = state.val;
-            entity.context.ATTRIBUTES = [{attribute: 'is_on', getId: entity.context.STATE.getId}];
-            entity.context.COMMANDS = [{
-                service: 'turn_on',
-                setId: entity.context.STATE.setId,
-                on: true,
-                parseCommand: (entity, command, data, user) =>
-                new Promise((resolve, reject) =>
-                    {
-                    this.adapter.setForeignState(command.setId, command.on, false, {user}, err => err ? reject(err): true);
-                     this._sendResponse(ws, data.id);
-                    resolve();})
-            },
-            {
-                service: 'turn_off',
-                setId: entity.context.STATE.setId,
-                off: false,
-                parseCommand: (entity, command, data, user) =>
-                    new Promise((resolve, reject) =>
-                        {
-                        this.adapter.setForeignState(command.setId, command.off, false, {user}, err => err ? reject(err): true);
-                         this._sendResponse(ws, data.id);
-                        resolve();})
-            }];
-        });
-
-        */
-
-        return [entity];
-    }
-
     _processLight(id, control, name, room, func, _obj) {
-        const entity = this._processCommon(id, name, room, func, _obj, 'light');
+        const entity = this._processCommon(name, room, func, _obj, 'light');
 
         let state = control.states.find(s => s.id && s.name === 'SET');
         entity.context.STATE = {setId: null, getId: null};
@@ -470,7 +309,7 @@ class WebServer {
     }
 
     _processWeather(id, control, name, room, func, _obj) {
-        const entity = this._processCommon(id, name, room, func, _obj, 'weather');
+        const entity = this._processCommon(name, room, func, _obj, 'weather');
 
         // - weather => STATE any-text(no icon)/clear-night/cloudy/fog/hail/lightning/lightning-rainy/partlycloudy/pouring/rainy/snowy/snowy-rainy/sunny/windy/windy-variant, attributes: [temperature, pressure, humidity, wind_speed, wind_bearing, forecast]
         //        forecast is an array with max 5 items [{datetime: something for new Date(aa), temperature, templow, condition(see STATE), precipitation}, {...}]
@@ -647,7 +486,7 @@ class WebServer {
     }
 
     _processAccuWeather(id, control, name, room, func, _obj) {
-        const entity = this._processCommon(id, name, room, func, _obj, 'weather');
+        const entity = this._processCommon(name, room, func, _obj, 'weather');
 
         // - weather => STATE any-text(no icon)/clear-night/cloudy/fog/hail/lightning/lightning-rainy/partlycloudy/pouring/rainy/snowy/snowy-rainy/sunny/windy/windy-variant, attributes: [temperature, pressure, humidity, wind_speed, wind_bearing, forecast]
         //        forecast is an array with max 5 items [{datetime: something for new Date(aa), temperature, templow, condition(see STATE), precipitation}, {...}]
@@ -830,7 +669,7 @@ class WebServer {
 
             if (state && state.id) {
                 //also create input_number - slider to be backwards compatibel:
-                const entitySlider = this._processCommon(id, entity.attributes.friendly_name, room, func, _obj, 'input_number');
+                const entitySlider = this._processCommon(entity.attributes.friendly_name, room, func, _obj, 'input_number');
                 entities.push(entitySlider);
                 entitySlider.context.STATE = {setId: state.id, getId: state.id};
                 entitySlider.attributes.icon = 'mdi:window-shutter';
@@ -976,7 +815,7 @@ class WebServer {
 
 
     _processBlind(id, control, name, room, func, _obj, objects) {
-        const entity = this._processCommon(id, name, room, func, _obj, 'cover');
+        const entity = this._processCommon(name, room, func, _obj, 'cover');
 
         /*
             cover device classes.
@@ -1078,7 +917,7 @@ class WebServer {
 
     _processLocation(id, control, name, room, func, _obj) {
         // - geo_location => attributes: [latitude, longitude, passive, icon, radius, entity_picture, gps_accuracy, source]
-        const entity = this._processCommon(id, name, room, func, _obj, 'geo_location');
+        const entity = this._processCommon(name, room, func, _obj, 'geo_location');
 
         entity.context.STATE = {getId: null};
         entity.context.ATTRIBUTES = [];
@@ -1135,7 +974,7 @@ class WebServer {
 
     _processImage(id, control, name, room, func, _obj) {
         // - geo_location => attributes: [latitude, longitude, passive, icon, radius, entity_picture, gps_accuracy, source]
-        const entity = this._processCommon(id, name, room, func, _obj, 'camera');
+        const entity = this._processCommon(name, room, func, _obj, 'camera');
 
         entity.context.STATE = {getId: null};
         entity.context.ATTRIBUTES = [];
@@ -1215,7 +1054,7 @@ class WebServer {
         //          shuffle 0x8000,
         //          select_sound_mode (0x10000)
 
-        const entity = this._processCommon(id, name, room, func, _obj, 'media_player');
+        const entity = this._processCommon(name, room, func, _obj, 'media_player');
 
         entity.context.STATE = {getId: null};
         entity.context.ATTRIBUTES = [];
@@ -2115,7 +1954,7 @@ class WebServer {
     _processLightAdvanced(id, control, name, room, func, _obj, objects) {
         const state = this._getLightAdvancedState(control);
         if (state && state.id) {
-            const entity = this._processCommon(id, name, func, room, _obj, 'light');
+            const entity = this._processCommon(name, func, room, _obj, 'light');
 
             //fill in on/off state id.
             this._lightAdvancedAddState(control,state, entity);
@@ -2169,7 +2008,7 @@ class WebServer {
     }
 
     _processDoor(id, control, name, room, func, _obj, objects) {
-        const entity = this._processCommon(id, name, room, func, _obj, 'binary_sensor');
+        const entity = this._processCommon(name, room, func, _obj, 'binary_sensor');
 
         const state = control.states.find(s => s.id && s.name === 'ACTUAL');
         entity.context.STATE = {getId: null};
@@ -2184,7 +2023,7 @@ class WebServer {
     }
 
     _processWindow(id, control, name, room, func, _obj, objects) {
-        const entity = this._processCommon(id, name, room, func, _obj, 'binary_sensor');
+        const entity = this._processCommon(name, room, func, _obj, 'binary_sensor');
 
         const state = control.states.find(s => s.id && s.name === 'ACTUAL');
         entity.context.STATE = {getId: null};
@@ -2199,7 +2038,7 @@ class WebServer {
     }
 
     _processWindowTilt(id, control, name, room, func, _obj, objects) {
-        const entity = this._processCommon(id, name, room, func, _obj, 'sensor');
+        const entity = this._processCommon(name, room, func, _obj, 'sensor');
 
         const state = control.states.find(s => s.id && s.name === 'ACTUAL');
         entity.context.STATE = {getId: null};
@@ -2232,7 +2071,7 @@ class WebServer {
     _processBattery(control, name, room, func, objects) {
         const state = control.states.find(s => s.id && s.name === 'LOWBAT');
         if (state && state.id) {
-            const entity = this._processCommon(state.id, name, room, func, objects[state.id], 'sensor');
+            const entity = this._processCommon(name, room, func, objects[state.id], 'sensor');
             entity.context.STATE = {getId: state.id};
             entity.context.iobType = 'LOWBAT';
             entity.attributes.icon = 'mdi:battery-alert';
@@ -2246,7 +2085,7 @@ class WebServer {
     }
 
     _processMotion(id, control, name, room, func, _obj, objects) {
-        const entity = this._processCommon(id, name, room, func, _obj, 'binary_sensor');
+        const entity = this._processCommon(name, room, func, _obj, 'binary_sensor');
 
         const state = control.states.find(s => s.id && s.name === 'ACTUAL');
         entity.context.STATE = {getId: null};
@@ -2261,7 +2100,7 @@ class WebServer {
     }
 
     _processLock(id, control, name, room, func, _obj, objects) {
-        const entity = this._processCommon(id, name, room, func, _obj, 'lock');
+        const entity = this._processCommon(name, room, func, _obj, 'lock');
 
         let state = control.states.find(s => s.id && s.name === 'SET');
         entity.context.STATE = {setId: null, getId: null};
@@ -2298,7 +2137,7 @@ class WebServer {
         let entity;
         let state = control.states.find(s => s.id && s.name === 'ACTUAL'); // temperature
         if (state && state.id) {
-            entity = this._processCommon(state.id, name, room, func, objects[state.id], 'sensor');
+            entity = this._processCommon(name, room, func, objects[state.id], 'sensor');
             entity.context.STATE = {getId: state.id};
             entity.attributes.device_class = 'temperature';
             this._addID2entity(state.id, entity);
@@ -2307,7 +2146,7 @@ class WebServer {
         state = control.states.find(s => s.id && s.name === 'SECOND'); // humidity
         let entityHum;
         if (state && state.id) {
-            entityHum = this._processCommon(state.id, name, room, func, objects[state.id], 'sensor');
+            entityHum = this._processCommon(name, room, func, objects[state.id], 'sensor');
             entityHum.context.STATE = {getId: state.id};
             entityHum.attributes.icon = 'mdi:mdi-water';
             entityHum.attributes.device_class = 'humidity';
@@ -2320,7 +2159,7 @@ class WebServer {
 
     _processThermostat(id, control, name, room, func, _obj, objects) {
         // - climate => STATE on/off, attributes: [current_temperature, operation_mode, operation_list, target_temp_step, target_temp_low, target_temp_high, min_temp, max_temp, temperature], commands:
-        const entity = this._processCommon(id, name, room, func, _obj, 'climate');
+        const entity = this._processCommon(name, room, func, _obj, 'climate');
 
         let state = control.states.find(s => s.id && s.name === 'POWER');
         entity.context.STATE = {setId: null, getId: null};
@@ -2377,7 +2216,7 @@ class WebServer {
         let entryHum;
         state = control.states.find(s => s.id && s.name === 'HUMIDITY');
         if (state && state.id) {
-            entryHum = this._processCommon(state.id, name, room, func, objects[state.id], 'sensor');
+            entryHum = this._processCommon(name, room, func, objects[state.id], 'sensor');
             entryHum.context.STATE = {getId: state.id};
             entryHum.attributes.icon = 'mdi:mdi-water';
             entryHum.attributes.device_class = 'humidity';
@@ -2420,13 +2259,10 @@ class WebServer {
                 obj.common.custom[this.adapter.namespace].entity = 'alarm_control_panel';
             }
             const entityType = obj.common.custom[this.adapter.namespace].entity;
-            let idPart = obj.common.custom[this.adapter.namespace].name;
-            if (!idPart || typeof idPart !== 'string') {
-                idPart = this._generateName(obj, 'en');
-            }
-            idPart = replaceInvalidChars(idPart);
+            const idPart = obj.common.custom[this.adapter.namespace].name;
+            const entity_id = idPart && typeof idPart === 'string' ? entityType + '.' + idPart : null;
 
-            const entity = this._processCommon(id, null, null, null, obj, entityType, entityType + '.' + idPart);
+            const entity = this._processCommon(null, null, null, obj, entityType, entity_id);
 
             entity.context.STATE = {getId: id, setId: id};
             entity.isManual = true;
@@ -2582,6 +2418,11 @@ class WebServer {
     }
 
     _processCall(ws, data) {
+        if (!data.service) {
+            this.log.warn('Invalid service call. Make sure service looks like domain.service_name');
+            return;
+        }
+
         if (data.service === 'dismiss') {
             this.log.debug('dismiss ' + data.service_data.notification_id);
 
@@ -3241,51 +3082,6 @@ class WebServer {
                 });
             });
         });
-    }
-
-    __getObjectName(obj, _lang) {
-        _lang = _lang || this.lang;
-
-        if (obj && obj.common && obj.common.name) {
-            if (typeof obj.common.name === 'object') {
-                if (obj.common.name[_lang] || obj.common.name.en) {
-                    return obj.common.name[_lang] || obj.common.name.en;
-                } else {
-                    const lang = Object.keys(obj.common.name).find(lang => obj.common.name[lang]);
-                    if (obj.common.name[lang]) {
-                        return obj.common.name[lang];
-                    } else {
-                        return obj._id;
-                    }
-                }
-            } else {
-                return obj.common.name;
-            }
-        } else {
-            return obj ? obj._id || '' : '';
-        }
-    }
-
-    _getObjectName(obj, __lang) {
-        const objName = this.__getObjectName(obj, __lang);
-        const pinyinObjNameObj = pinyin(objName, {style: pinyin.STYLE_TONE2});
-        if (typeof pinyinObjNameObj === 'object' && pinyinObjNameObj.length > 1) {
-            // Found Chinese word.
-            // "Chinese中文" => [ [ 'Chinese' ], [ 'zhong1' ], [ 'wen2' ] ]
-            let pinyinObjName = '';
-            for (let i = 0; i < pinyinObjNameObj.length; i++) {
-                if (typeof pinyinObjNameObj[i] === 'object') {
-                    pinyinObjName += pinyinObjNameObj[i][0];
-                }
-            }
-            return pinyinObjName;
-        }
-        // No Chinese word found, return origin object name
-        return objName;
-    }
-
-    _generateName(obj, lang) {
-        return this._getObjectName(obj, lang).replace(/[^-._\w0-9А-Яа-яÄÜÖßäöü ]/g, '_');
     }
 
     _processEntities(ids, cb, _entities) {
@@ -4176,7 +3972,7 @@ class WebServer {
         this.adapter.getForeignObject(user, {user}, (err, obj) => {
             cb({
                 id: user,
-                name: this._getObjectName(obj),
+                name: utils.getObjectName(obj),
                 is_owner: user === 'system.user.admin',
                 is_admin: user === 'system.user.admin',
                 credentials: [{auth_provider_type: 'iobroker', auth_provider_id: null}],

--- a/lib/server.js
+++ b/lib/server.js
@@ -2325,7 +2325,6 @@ class WebServer {
         let state = control.states.find(s => s.id && s.name === 'POWER');
         entity.context.STATE = {setId: null, getId: null};
         entity.attributes.icon = 'mdi:thermostat';
-        entity.state = 'auto'; //set to auto, if no "mode" // power-state present?
 
         if (state && state.id) {
             entity.context.STATE.setId = state.id;


### PR DESCRIPTION
@GermanBluefox 
Please have a look. I started to refactor lib/server.js.

The plan is to first extract most of the converters code (this what I know best, currently).

- First I extracted _processCommon and other utils functions to converters/utils.js
- Then I extracted _processSocket.js to converters/switch.js 
- Next I plan to create a *.js file in converters/ folder for each (relevant) HASS-domain which contains all converters that convert an ioBroker device-type to that domain (for example rgb, rgbsingle, ... to light.js and so on). 

I also added some tests. I plan to expand them further to prevent breaking things while adding new stuff as good as possible.

I decided to let keep the arrays in server.js and bind(this) to the converter functions, so they will still fill them. It works quite nice currently, but I'd like to get a comment on that. Is that a good design, or should I change that and (for example) hand the arrays over to the converter functions or similar? (_addID2Entity function is used intensively by the converters and adds things to the server-objects, which are required in other functions that handle subscriptions / updates / commands).

I created this PR mostly for discussion.