### PR TITLE
Darktheme config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ## __WORK IN PROGRESS__
 * (thost96) Fixed: set Theme state type to string instead of text
+* (thost96) Added: Darktheme config option 
 
 ## 1.3.6 (2021-01-08)
 * (Garfonso) Fixed: do not ignore devices deleted from iot / without smartName

--- a/io-package.json
+++ b/io-package.json
@@ -515,6 +515,20 @@
             }
         },
         {
+            "_id": "control.darktheme",
+            "type": "state",
+            "common": {
+                "name": "darktheme",
+                "type": "string",
+                "write": true,
+                "read": false,
+                "desc": "Change default darktheme during runtime",
+                "states": {
+                    "default": "default"
+                }
+            }
+        },
+        {
             "_id": "notifications",
             "type": "channel",
             "common": {


### PR DESCRIPTION
Hi,

as I have seen there is no config option in the iobroker objects to configure the dark theme as it is for the normal theme. Maybe this has been missed. I'm also not sure if any further changes are necessary, as the dark theme configuration is already implemented. 

