### PR TITLE
Fix Blinds TILT Option and Include Inversion of Blind Setting for TILT_ACTUAL

### DIFF
--- a/lib/converters/cover.js
+++ b/lib/converters/cover.js
@@ -175,7 +175,7 @@ function addTiltLevel(entity, control, objects, name) {
 
         const getState = control.states.find(s => s.id && s.name === name.replace('SET', 'ACTUAL'));
         if (getState && getState.id) {
-            entity.context.STATE.getId = getState.id;
+            entity.context.ATTRIBUTES.find(a => a.attribute === 'tilt').getId = getState.id;
             utils.addID2entity(getState.id, entity);
         }
         return true;
@@ -230,7 +230,7 @@ exports.processBlind = function(id, control, name, room, func, _obj, objects, fo
 
     if(addTiltLevel(entity, control, objects, 'TILT_SET')) {
         const attr = entity.context.ATTRIBUTES.find(a => a.attribute === 'tilt');
-        attr.invert = false;
+        attr.invert = !!adapterData.adapter.config.blindsInvert;
     }
 
     //add commands, if present:


### PR DESCRIPTION
Added solution for https://github.com/ioBroker/ioBroker.lovelace/issues/492 (Blinds with tilt option not working correctly).
In addition the tilt value now supports the adapter's blind inversion setting.