### PR TITLE
require node 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
     "type": "git",
     "url": "https://github.com/ioBroker/ioBroker.lovelace"
   },
+  "engines": {
+    "node": ">= 18"
+  },
   "dependencies": {
     "@iobroker/adapter-core": "^3.0.4",
     "@iobroker/webserver": "^1.0.3",


### PR DESCRIPTION
Your adapter uses adater-core 3.x.x. adapter-core 3.x.x is known to fail with node <= 14 during install. In addtion node 16 is EOL. So this adapter should require node 18 minimum now.

Please check PR and merge for next normal (non patch) release.